### PR TITLE
Fix: Call to a member function can() on null

### DIFF
--- a/src/Http/Livewire/Pages/CategoryShow.php
+++ b/src/Http/Livewire/Pages/CategoryShow.php
@@ -224,7 +224,6 @@ class CategoryShow extends Component
             ? $this->category->threads()->withTrashed()
             : $this->category->threads();
 
-        // if ($this->category->requiresThreadApproval() && !$request->user() || !$request->user()->can('approveThreads', $this->category)) {
         if ($this->category->requiresThreadApproval() && (!$request->user() || !$request->user()->can('approveThreads', $this->category))) {
 
             $threads = $threads->authoredByOrApproved($request->user());

--- a/src/Http/Livewire/Pages/CategoryShow.php
+++ b/src/Http/Livewire/Pages/CategoryShow.php
@@ -224,7 +224,9 @@ class CategoryShow extends Component
             ? $this->category->threads()->withTrashed()
             : $this->category->threads();
 
-        if ($this->category->requiresThreadApproval() && !$request->user() || !$request->user()->can('approveThreads', $this->category)) {
+        // if ($this->category->requiresThreadApproval() && !$request->user() || !$request->user()->can('approveThreads', $this->category)) {
+        if ($this->category->requiresThreadApproval() && (!$request->user() || !$request->user()->can('approveThreads', $this->category))) {
+
             $threads = $threads->authoredByOrApproved($request->user());
         }
 


### PR DESCRIPTION
When you are not logged in, ` $request->user() is null.` The issue is due to a missing pair of parentheses in line number 227 of CategoryShow.php file that leads to an operator precedence bug.In PHP, the && operator has a higher precedence than the || operator.

When you are not logged in, `$request->user()` is null. PHP evaluates the condition as follows:

($this->category->requiresThreadApproval() && !$request->user())
`||`
`!$request->user()->can('approveThreads', $this->category)`

If the first part evaluates to false (e.g., if thread approval isn't required), PHP moves on to the right side of the || operator. Because you are not logged in `($request->user() is null)`, trying to `call ->can(...) on null `triggers the fatal error you experienced.

The Fix:
`if ($this->category->requiresThreadApproval() && (!$request->user() || !$request->user()->can('approveThreads', $this->category))) {
`