### PR TITLE
Lazy Loading Fixes

### DIFF
--- a/src/Http/Livewire/Pages/PostShow.php
+++ b/src/Http/Livewire/Pages/PostShow.php
@@ -14,7 +14,7 @@ class PostShow extends Component
 {
     public function render(Request $request): View
     {
-        $post = $request->route('post')->load('thread.category');
+        $post = $request->route('post')->load('thread.category', 'parent', 'parent.author', 'parent.thread.category');
 
         if (!$post->isAccessibleTo($request->user())) {
             abort(404);

--- a/src/Http/Livewire/Pages/PostShow.php
+++ b/src/Http/Livewire/Pages/PostShow.php
@@ -14,7 +14,7 @@ class PostShow extends Component
 {
     public function render(Request $request): View
     {
-        $post = $request->route('post');
+        $post = $request->route('post')->load('thread.category');
 
         if (!$post->isAccessibleTo($request->user())) {
             abort(404);

--- a/src/Http/Livewire/Pages/PostsPendingApproval.php
+++ b/src/Http/Livewire/Pages/PostsPendingApproval.php
@@ -34,7 +34,7 @@ class PostsPendingApproval extends Component
             ->notFirstInThread()
             ->pendingApproval()
             ->orderBy('created_at', 'desc')
-            ->with('thread', 'author');
+            ->with('thread.category', 'author', 'parent', 'parent.author', 'parent.thread.category');
 
         $accessibleCategoryIds = CategoryAccess::getFilteredIdsFor($request->user());
 

--- a/src/Http/Livewire/Pages/ThreadReply.php
+++ b/src/Http/Livewire/Pages/ThreadReply.php
@@ -30,14 +30,14 @@ class ThreadReply extends Component
 
     public function mount(Request $request)
     {
-        $this->thread = $request->route('thread');
+        $this->thread = $request->route('thread')->load('category');
 
         if (!$this->thread->category->isAccessibleTo($request->user())) {
             abort(404);
         }
 
         if ($request->input('parent_id')) {
-            $this->parent = $this->thread->posts->find($request->input('parent_id'));
+            $this->parent = $this->thread->posts()->find($request->input('parent_id'));
         }
 
         UserCreatingPost::dispatch($request->user(), $this->thread);

--- a/src/Http/Livewire/Pages/ThreadShow.php
+++ b/src/Http/Livewire/Pages/ThreadShow.php
@@ -42,7 +42,7 @@ class ThreadShow extends EventfulPaginatedComponent
 
     public function mount(Request $request)
     {
-        $this->thread = $request->route('thread');
+        $this->thread = $request->route('thread')->load('category');
 
         if (!$this->thread->isAccessibleTo($request->user())) {
             abort(404);

--- a/src/Http/Livewire/Pages/ThreadShow.php
+++ b/src/Http/Livewire/Pages/ThreadShow.php
@@ -243,7 +243,7 @@ class ThreadShow extends EventfulPaginatedComponent
         }
 
         $posts = $postsQuery
-            ->with('author', 'thread')
+            ->with('author', 'thread.category', 'parent', 'parent.author', 'parent.thread.category')
             ->orderBy('created_at', 'asc')
             ->paginate();
 

--- a/src/Models/Thread.php
+++ b/src/Models/Thread.php
@@ -90,7 +90,7 @@ class Thread extends BaseModel
 
     public function scopeWithPostAndAuthorRelationships(Builder $query): Builder
     {
-        return $query->with('firstPost', 'lastPost', 'firstPost.author', 'lastPost.author', 'lastPost.thread', 'author');
+        return $query->with('category', 'firstPost', 'lastPost', 'firstPost.author', 'lastPost.author', 'lastPost.thread', 'author');
     }
 
     public function scopeOrdered(Builder $query): Builder

--- a/src/Support/Access/CategoryAccess.php
+++ b/src/Support/Access/CategoryAccess.php
@@ -15,7 +15,7 @@ use TeamTeaTime\Forum\Models\Thread;
 class CategoryAccess
 {
     const DEFAULT_SELECT = ['*'];
-    const DEFAULT_WITH = ['newestThread', 'latestActiveThread', 'newestThread.lastPost', 'latestActiveThread.lastPost'];
+    const DEFAULT_WITH = ['newestThread', 'latestActiveThread', 'newestThread.lastPost.thread', 'latestActiveThread.lastPost.thread'];
 
     public static function getPrivateAncestor(?User $user, Category $category): ?Category
     {


### PR DESCRIPTION
* Modified **`scopeWithPostAndAuthorRelationships`** in `Thread.php`.

* Updated **`DEFAULT_WITH`** in `CategoryAccess.php` to use **`newestThread.lastPost.thread`** and **`latestActiveThread.lastPost.thread`**.

* Changed **'mount()'** in `ThreadShow.php` to manually execute **`$request->route('thread')->load('category')`**

* Modified **`render()`** in `PostShow.php` to run **`$post->load('thread.category')`**.

* Changed **`mount()`** in ThreadReply.php to eager load category. Replaced `$this->thread->posts->find(...)` with a database query **`$this->thread->posts()->find(...)`**, ensuring we don't load the entire thread's post history into application memory.