### PR TITLE
Lazy load fix for Blade-tailwind preset

### DIFF
--- a/src/Http/Controllers/Blade/PostController.php
+++ b/src/Http/Controllers/Blade/PostController.php
@@ -28,6 +28,8 @@ class PostController extends BaseController
             abort(404);
         }
 
+        $post->load(['parent', 'parent.author', 'parent.thread', 'parent.thread.category']);
+
         if ($request->user() !== null) {
             UserViewingPost::dispatch($request->user(), $post);
         }
@@ -44,6 +46,10 @@ class PostController extends BaseController
         UserCreatingPost::dispatch($request->user(), $thread);
 
         $post = $request->has('post_id') ? $thread->posts->find($request->input('post_id')) : null;
+
+        if ($post !== null) {
+            $post->load(['author', 'thread']);
+        }
 
         return ViewFactory::make('forum::post.create', compact('thread', 'post'));
     }
@@ -70,11 +76,12 @@ class PostController extends BaseController
         }
 
         $this->authorize('edit', $post);
-
-        UserEditingPost::dispatch($request->user(), $post);
-
+        
         $thread = $post->thread;
         $category = $post->thread->category;
+        $post->load(['parent', 'parent.author', 'parent.thread', 'parent.thread.category']);
+
+        UserEditingPost::dispatch($request->user(), $post);
 
         return ViewFactory::make('forum::post.edit', compact('category', 'thread', 'post'));
     }
@@ -96,6 +103,7 @@ class PostController extends BaseController
     {
         $thread = $request->route('thread');
         $post = $request->route('post');
+        $post->load(['parent', 'parent.author', 'parent.thread', 'parent.thread.category']);
 
         return ViewFactory::make('forum::post.confirm-delete', ['category' => $thread->category, 'thread' => $thread, 'post' => $post]);
     }
@@ -104,6 +112,7 @@ class PostController extends BaseController
     {
         $thread = $request->route('thread');
         $post = $request->route('post');
+        $post->load(['parent', 'parent.author', 'parent.thread', 'parent.thread.category']);
 
         return ViewFactory::make('forum::post.confirm-restore', ['category' => $thread->category, 'thread' => $thread, 'post' => $post]);
     }
@@ -140,7 +149,7 @@ class PostController extends BaseController
             ->notFirstInThread()
             ->pendingApproval()
             ->orderBy('created_at', 'desc')
-            ->with('thread', 'author');
+            ->with('thread', 'thread.category', 'author', 'parent', 'parent.thread', 'parent.thread.category');
 
         // Get accessible category IDs for the current user
         $accessibleCategoryIds = CategoryAccess::getFilteredIdsFor($request->user());

--- a/src/Http/Controllers/Blade/ThreadController.php
+++ b/src/Http/Controllers/Blade/ThreadController.php
@@ -121,7 +121,7 @@ class ThreadController extends BaseController
         }
 
         $posts = $postsQuery
-            ->with('author', 'thread')
+            ->with('author', 'thread', 'parent', 'parent.author', 'parent.thread', 'parent.thread.category')
             ->orderBy('created_at', 'asc')
             ->paginate();
 
@@ -303,7 +303,7 @@ class ThreadController extends BaseController
         $threads = Thread::notDeleted()
             ->pendingApproval()
             ->orderBy('created_at', 'desc')
-            ->with('category', 'author', 'lastPost', 'lastPost.author', 'lastPost.thread');
+            ->with('category', 'firstPost', 'author', 'lastPost', 'lastPost.author', 'lastPost.thread');
 
         // Get accessible category IDs for the current user
         $accessibleCategoryIds = CategoryAccess::getFilteredIdsFor($request->user());

--- a/src/Http/Livewire/Pages/PostShow.php
+++ b/src/Http/Livewire/Pages/PostShow.php
@@ -14,7 +14,7 @@ class PostShow extends Component
 {
     public function render(Request $request): View
     {
-        $post = $request->route('post')->load('thread.category');
+        $post = $request->route('post')->load('thread.category', 'parent', 'parent.author', 'parent.thread.category');
 
         if (!$post->isAccessibleTo($request->user())) {
             abort(404);

--- a/src/Http/Livewire/Pages/PostShow.php
+++ b/src/Http/Livewire/Pages/PostShow.php
@@ -14,7 +14,7 @@ class PostShow extends Component
 {
     public function render(Request $request): View
     {
-        $post = $request->route('post');
+        $post = $request->route('post')->load('thread.category');
 
         if (!$post->isAccessibleTo($request->user())) {
             abort(404);

--- a/src/Http/Livewire/Pages/PostsPendingApproval.php
+++ b/src/Http/Livewire/Pages/PostsPendingApproval.php
@@ -34,7 +34,7 @@ class PostsPendingApproval extends Component
             ->notFirstInThread()
             ->pendingApproval()
             ->orderBy('created_at', 'desc')
-            ->with('thread', 'author');
+            ->with('thread.category', 'author', 'parent', 'parent.author', 'parent.thread.category');
 
         $accessibleCategoryIds = CategoryAccess::getFilteredIdsFor($request->user());
 

--- a/src/Http/Livewire/Pages/ThreadReply.php
+++ b/src/Http/Livewire/Pages/ThreadReply.php
@@ -30,14 +30,14 @@ class ThreadReply extends Component
 
     public function mount(Request $request)
     {
-        $this->thread = $request->route('thread');
+        $this->thread = $request->route('thread')->load('category');
 
         if (!$this->thread->category->isAccessibleTo($request->user())) {
             abort(404);
         }
 
         if ($request->input('parent_id')) {
-            $this->parent = $this->thread->posts->find($request->input('parent_id'));
+            $this->parent = $this->thread->posts()->find($request->input('parent_id'));
         }
 
         UserCreatingPost::dispatch($request->user(), $this->thread);

--- a/src/Http/Livewire/Pages/ThreadShow.php
+++ b/src/Http/Livewire/Pages/ThreadShow.php
@@ -42,7 +42,7 @@ class ThreadShow extends EventfulPaginatedComponent
 
     public function mount(Request $request)
     {
-        $this->thread = $request->route('thread');
+        $this->thread = $request->route('thread')->load('category');
 
         if (!$this->thread->isAccessibleTo($request->user())) {
             abort(404);

--- a/src/Http/Livewire/Pages/ThreadShow.php
+++ b/src/Http/Livewire/Pages/ThreadShow.php
@@ -243,7 +243,7 @@ class ThreadShow extends EventfulPaginatedComponent
         }
 
         $posts = $postsQuery
-            ->with('author', 'thread')
+            ->with('author', 'thread.category', 'parent', 'parent.author', 'parent.thread.category')
             ->orderBy('created_at', 'asc')
             ->paginate();
 

--- a/src/Models/Thread.php
+++ b/src/Models/Thread.php
@@ -90,7 +90,7 @@ class Thread extends BaseModel
 
     public function scopeWithPostAndAuthorRelationships(Builder $query): Builder
     {
-        return $query->with('firstPost', 'lastPost', 'firstPost.author', 'lastPost.author', 'lastPost.thread', 'author');
+        return $query->with('category', 'firstPost', 'lastPost', 'firstPost.author', 'lastPost.author', 'lastPost.thread', 'author');
     }
 
     public function scopeOrdered(Builder $query): Builder

--- a/src/Support/Access/CategoryAccess.php
+++ b/src/Support/Access/CategoryAccess.php
@@ -15,7 +15,7 @@ use TeamTeaTime\Forum\Models\Thread;
 class CategoryAccess
 {
     const DEFAULT_SELECT = ['*'];
-    const DEFAULT_WITH = ['newestThread', 'latestActiveThread', 'newestThread.lastPost', 'latestActiveThread.lastPost'];
+    const DEFAULT_WITH = ['newestThread', 'latestActiveThread', 'newestThread.lastPost.thread', 'latestActiveThread.lastPost.thread'];
 
     public static function getPrivateAncestor(?User $user, Category $category): ?Category
     {


### PR DESCRIPTION
-  Modified **`Http/Controllers/Blade/ThreadController.php`** so that when viewing a thread, the `posts query `eager loads **_`parent`_**, **_`parent.author`_**, **_`parent.thread`_**, and **_`parent.thread.category`_**.

-  Modified Http/Controllers/Blade/PostController.php to explicitly load those same relationships when fetching a single `post for viewing, editing, deleting, or restoring.`